### PR TITLE
Export blockexplorer as ethscan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@owodunni/ethscan",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A simple CLI for querying contract information from block-explorers",
-  "main": "index.js",
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/owodunni/ethscan.git"

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+exports.ethscan = require("./etherscan");


### PR DESCRIPTION
This allows ethscan to be used as a simple library in other npm packages.